### PR TITLE
Bugfix: stop lose and take profit must be float

### DIFF
--- a/iqoptionapi/ws/chanels/buy_place_order_temp.py
+++ b/iqoptionapi/ws/chanels/buy_place_order_temp.py
@@ -20,8 +20,8 @@ class Buy_place_order_temp(Base):
             "leverage":int(leverage),
             "limit_price":int(limit_price),
             "stop_price":int(stop_price),
-            "stop_lose_price":int(stop_lose_price),
-            "take_profit_price":int(take_profit_price),
+            "stop_lose_price":float(stop_lose_price),
+            "take_profit_price":float(take_profit_price),
             "use_token_for_commission":"false",
             "auto_margin_call":"false"    
             }


### PR DESCRIPTION
If you buy/sell e.g. forex on EURUSD, you can't specify the correct stop lose and take profit if the values are converted to int. So this PR will fix this issue and send them in the correct form.