### PR TITLE
BugFix - Error in get binary result

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,6 +1291,8 @@ I_want_money.unsubscribe_top_assets_updated(instrument_type)
 ---
 ### Get mood
 
+for now... only support get binary option mood , i will implement beterr if need..
+
 Sample
 
 ```python


### PR DESCRIPTION
Sometimes when time gets the result api returns error of data not found or something like that.
Only if the api returns that already has the result of the operation is not returned in the array then the system throws an error.
I put a try cath so that the system does not present this error.