### PR TITLE
For faster result obtaining from Binary or Turbo

### DIFF
--- a/iqoptionapi/stable_api.py
+++ b/iqoptionapi/stable_api.py
@@ -227,8 +227,7 @@ class IQ_Option:
                         OPEN_TIME[option][name]["open"]=True
                 else:
                     OPEN_TIME[option][name]["open"]=active["enabled"]
-
-                
+        
         #for digital
         digital_data=self.get_digital_underlying_list_data()["underlying"]
         for digital in digital_data:
@@ -262,7 +261,25 @@ class IQ_Option:
 
         return OPEN_TIME
                     
-       
+    # for faster checking the information reation to option active    
+    def check_active_option(self,symbol_name,type_local="turbo"):
+        #for binary option turbo and binary
+        decision_local = False
+        data_values=self.get_all_init_v2()
+        for actives_id in data_values[type_local]["actives"]:
+            active=data_values[type_local]["actives"][actives_id]
+            if symbol_name in str(active["name"]):
+                if active["enabled"]==True:
+                    if active["is_suspended"]==True:
+                        decision_local = False
+                        break
+                    else:
+                        decision_local= True
+                        break
+                else:
+                    decision_local = active["enabled"]
+        return decision_local
+      
 
 # --------for binary option detail
 


### PR DESCRIPTION
The time taken by the get_all_open_time() is too much. It is around 3 to 4 seconds for me. So introduced one function: check_active_option(symbol_name,type_local="turbo").
Results: 
>>> start = time.time()
>>> I_want_money.check_active_option("GBPUSD","turbo")
False
>>> print(time.time()-start)
1.88875150680542
>>> start = time.time()
>>> I_want_money.check_active_option("GBPUSD","binary")
True
>>> print(time.time()-start)
1.612823247909546
>>> start = time.time()
>>> ALL_Asset=I_want_money.get_all_open_time()
>>> print(ALL_Asset["turbo"]["GBPUSD"]["open"])
False
>>> print(time.time()-start)
3.9237112998962402
>>> start = time.time()
>>> I_want_money.check_active_option("GBPUSD","turbo")
False
>>> print(time.time()-start)
1.2794654369354248
>>> start = time.time()
>>> I_want_money.check_active_option("GBPUSD","binary")
True
>>> print(time.time()-start)
1.1873185634613037
>>> start = time.time()
>>> ALL_Asset=I_want_money.get_all_open_time()
>>> print(ALL_Asset["turbo"]["GBPUSD"]["open"])
False
>>> print(time.time()-start)
3.3454699516296387
>>> start = time.time()
>>> I_want_money.check_active_option("GBPUSD","turbo")
False
>>> print(time.time()-start)
1.0593905448913574
>>> start = time.time()
>>> I_want_money.check_active_option("GBPUSD","binary")
True
>>> print(time.time()-start)
1.1197316646575928
>>> start = time.time()
>>> ALL_Asset=I_want_money.get_all_open_time()
>>> print(ALL_Asset["turbo"]["GBPUSD"]["open"])
False
>>> print(time.time()-start)
3.4447529315948486